### PR TITLE
Throw an error when performRequest fails

### DIFF
--- a/TwitterAPIExchange.php
+++ b/TwitterAPIExchange.php
@@ -212,6 +212,14 @@ class TwitterAPIExchange
         $feed = curl_init();
         curl_setopt_array($feed, $options);
         $json = curl_exec($feed);
+     
+        if (false === $json)
+        {
+            $error = curl_error($feed);
+            curl_close($feed);
+            throw new Exception($error);
+        }
+        
         curl_close($feed);
 
         if ($return) { return $json; }


### PR DESCRIPTION
When performRequest fails, the user/developper gets no clue about what happened.
performRequest now throws an exception with the error returned by curl.