### PR TITLE
Fix to SSL Error on Some Servers

### DIFF
--- a/TwitterAPIExchange.php
+++ b/TwitterAPIExchange.php
@@ -195,6 +195,7 @@ class TwitterAPIExchange
             CURLOPT_URL => $this->url,
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_TIMEOUT => 10,
+            CURLOPT_SSL_VERIFYPEER => false
         );
 
         if (!is_null($postfields))


### PR DESCRIPTION
To fix the SSL error message "SSL certificate problem, verify that the CA cert is OK", I have set curl not not verify SSL.
