### PR TITLE
Trigger error to cURL to user

### DIFF
--- a/TwitterAPIExchange.php
+++ b/TwitterAPIExchange.php
@@ -211,7 +211,10 @@ class TwitterAPIExchange
 
         $feed = curl_init();
         curl_setopt_array($feed, $options);
-        $json = curl_exec($feed);
+        if (!$json = curl_exec($feed))
+        {
+            trigger_error(curl_error($feed));
+        } 
         curl_close($feed);
 
         if ($return) { return $json; }


### PR DESCRIPTION
Hi, I've just been trying out your TwitterAPIExchange class and couldn't get it to work at first.  This was because my cURL wasn't configured to allow SSL requests.  I had to make the change below for the error to be reported on screen.  Is it worth adding?
