### PR TITLE
fix oath signing when using POST

### DIFF
--- a/TwitterAPIExchange.php
+++ b/TwitterAPIExchange.php
@@ -158,6 +158,13 @@ class TwitterAPIExchange
                 $oauth[$split[0]] = $split[1];
             }
         }
+
+        $postfields = $this->getPostfields();
+        if (!is_null($postfields)) {
+            foreach ($postfields as $key => $value) {
+                $oauth[$key] = rawurlencode($value);
+            }
+        }
         
         $base_info = $this->buildBaseString($url, $requestMethod, $oauth);
         $composite_key = rawurlencode($consumer_secret) . '&' . rawurlencode($oauth_access_token_secret);
@@ -199,7 +206,7 @@ class TwitterAPIExchange
 
         if (!is_null($postfields))
         {
-            $options[CURLOPT_POSTFIELDS] = $postfields;
+            $options[CURLOPT_POSTFIELDS] = http_build_query($postfields);
         }
         else
         {


### PR DESCRIPTION
My attempt to fix #70 - The PHP cURL will use content-type "multipart/form-data" if data in post fields is an array. To use content-type "application/x-www-form-urlencoded", I need to convert post fields to string using http_build_query().

According to POST spec, we also need to include the post fields when we call buildBaseString() method.