### PR TITLE
Feature/additional curl options on request

### DIFF
--- a/TwitterAPIExchange.php
+++ b/TwitterAPIExchange.php
@@ -2,9 +2,9 @@
 
 /**
  * Twitter-API-PHP : Simple PHP wrapper for the v1.1 API
- * 
+ *
  * PHP version 5.3.10
- * 
+ *
  * @category Awesomeness
  * @package  Twitter-API-PHP
  * @author   James Mallison <me@j7mbo.co.uk>
@@ -13,13 +13,21 @@
  */
 class TwitterAPIExchange
 {
+
     private $oauth_access_token;
+
     private $oauth_access_token_secret;
+
     private $consumer_key;
+
     private $consumer_secret;
+
     private $postfields;
+
     private $getfield;
+
     protected $oauth;
+
     public $url;
 
     /**
@@ -27,239 +35,237 @@ class TwitterAPIExchange
      * oauth access token, oauth access token secret, consumer key, consumer secret
      * These are all available by creating your own application on dev.twitter.com
      * Requires the cURL library
-     * 
+     *
      * @param array $settings
+     *
+     * @throws Exception
      */
     public function __construct(array $settings)
     {
-        if (!in_array('curl', get_loaded_extensions())) 
-        {
+        if (!in_array('curl', get_loaded_extensions())) {
             throw new Exception('You need to install cURL, see: http://curl.haxx.se/docs/install.html');
         }
-        
+
         if (!isset($settings['oauth_access_token'])
             || !isset($settings['oauth_access_token_secret'])
             || !isset($settings['consumer_key'])
-            || !isset($settings['consumer_secret']))
-        {
+            || !isset($settings['consumer_secret'])
+        ) {
             throw new Exception('Make sure you are passing in the correct parameters');
         }
 
-        $this->oauth_access_token = $settings['oauth_access_token'];
+        $this->oauth_access_token        = $settings['oauth_access_token'];
         $this->oauth_access_token_secret = $settings['oauth_access_token_secret'];
-        $this->consumer_key = $settings['consumer_key'];
-        $this->consumer_secret = $settings['consumer_secret'];
+        $this->consumer_key              = $settings['consumer_key'];
+        $this->consumer_secret           = $settings['consumer_secret'];
     }
-    
+
     /**
      * Set postfields array, example: array('screen_name' => 'J7mbo')
-     * 
+     *
      * @param array $array Array of parameters to send to API
-     * 
+     *
      * @return TwitterAPIExchange Instance of self for method chaining
+     * @throws Exception
      */
     public function setPostfields(array $array)
     {
-        if (!is_null($this->getGetfield())) 
-        { 
-            throw new Exception('You can only choose get OR post fields.'); 
+        if (!is_null($this->getGetfield())) {
+            throw new Exception('You can only choose get OR post fields.');
         }
-        
-        if (isset($array['status']) && substr($array['status'], 0, 1) === '@')
-        {
+
+        if (isset($array['status']) && substr($array['status'], 0, 1) === '@') {
             $array['status'] = sprintf("\0%s", $array['status']);
         }
-        
+
         $this->postfields = $array;
-        
+
         return $this;
     }
-    
+
     /**
      * Set getfield string, example: '?screen_name=J7mbo'
-     * 
+     *
      * @param string $string Get key and value pairs as string
-     * 
-     * @return \TwitterAPIExchange Instance of self for method chaining
+     *
+     * @return TwitterAPIExchange Instance of self for method chaining
+     * @throws Exception
      */
     public function setGetfield($string)
     {
-        if (!is_null($this->getPostfields())) 
-        { 
-            throw new Exception('You can only choose get OR post fields.'); 
+        if (!is_null($this->getPostfields())) {
+            throw new Exception('You can only choose get OR post fields.');
         }
-        
-        $search = array('#', ',', '+', ':');
+
+        $search  = array('#', ',', '+', ':');
         $replace = array('%23', '%2C', '%2B', '%3A');
-        $string = str_replace($search, $replace, $string);  
-        
+        $string  = str_replace($search, $replace, $string);
+
         $this->getfield = $string;
-        
+
         return $this;
     }
-    
+
     /**
      * Get getfield string (simple getter)
-     * 
+     *
      * @return string $this->getfields
      */
     public function getGetfield()
     {
         return $this->getfield;
     }
-    
+
     /**
      * Get postfields array (simple getter)
-     * 
+     *
      * @return array $this->postfields
      */
     public function getPostfields()
     {
         return $this->postfields;
     }
-    
+
     /**
      * Build the Oauth object using params set in construct and additionals
      * passed to this method. For v1.1, see: https://dev.twitter.com/docs/api/1.1
-     * 
-     * @param string $url The API url to use. Example: https://api.twitter.com/1.1/search/tweets.json
+     *
+     * @param string $url           The API url to use. Example: https://api.twitter.com/1.1/search/tweets.json
      * @param string $requestMethod Either POST or GET
+     *
      * @return \TwitterAPIExchange Instance of self for method chaining
+     * @throws Exception
      */
     public function buildOauth($url, $requestMethod)
     {
-        if (!in_array(strtolower($requestMethod), array('post', 'get')))
-        {
+        if (!in_array(strtolower($requestMethod), array('post', 'get'))) {
             throw new Exception('Request method must be either POST or GET');
         }
-        
-        $consumer_key = $this->consumer_key;
-        $consumer_secret = $this->consumer_secret;
-        $oauth_access_token = $this->oauth_access_token;
+
+        $consumer_key              = $this->consumer_key;
+        $consumer_secret           = $this->consumer_secret;
+        $oauth_access_token        = $this->oauth_access_token;
         $oauth_access_token_secret = $this->oauth_access_token_secret;
-        
-        $oauth = array( 
-            'oauth_consumer_key' => $consumer_key,
-            'oauth_nonce' => time(),
+
+        $oauth = array(
+            'oauth_consumer_key'     => $consumer_key,
+            'oauth_nonce'            => time(),
             'oauth_signature_method' => 'HMAC-SHA1',
-            'oauth_token' => $oauth_access_token,
-            'oauth_timestamp' => time(),
-            'oauth_version' => '1.0'
+            'oauth_token'            => $oauth_access_token,
+            'oauth_timestamp'        => time(),
+            'oauth_version'          => '1.0'
         );
-        
+
         $getfield = $this->getGetfield();
-        
-        if (!is_null($getfield))
-        {
+
+        if (!is_null($getfield)) {
             $getfields = str_replace('?', '', explode('&', $getfield));
-            foreach ($getfields as $g)
-            {
-                $split = explode('=', $g);
+            foreach ($getfields as $g) {
+                $split            = explode('=', $g);
                 $oauth[$split[0]] = $split[1];
             }
         }
-        
-        $base_info = $this->buildBaseString($url, $requestMethod, $oauth);
-        $composite_key = rawurlencode($consumer_secret) . '&' . rawurlencode($oauth_access_token_secret);
-        $oauth_signature = base64_encode(hash_hmac('sha1', $base_info, $composite_key, true));
+
+        $base_info                = $this->buildBaseString($url, $requestMethod, $oauth);
+        $composite_key            = rawurlencode($consumer_secret) . '&' . rawurlencode($oauth_access_token_secret);
+        $oauth_signature          = base64_encode(hash_hmac('sha1', $base_info, $composite_key, true));
         $oauth['oauth_signature'] = $oauth_signature;
-        
-        $this->url = $url;
+
+        $this->url   = $url;
         $this->oauth = $oauth;
-        
+
         return $this;
     }
-    
+
     /**
      * Perform the actual data retrieval from the API
-     * 
+     *
      * @param boolean $return      If true, returns data.
      * @param array   $curlOptions Optional array of CURL Options
-     * 
+     *
      * @return string json If $return param is true, returns json data.
      * @throws Exception
      */
     public function performRequest($return = true, $curlOptions = array())
     {
-        if (!is_bool($return)) 
-        { 
-            throw new Exception('performRequest parameter must be true or false'); 
+        if (!is_bool($return)) {
+            throw new Exception('performRequest parameter must be true or false');
         }
-        
+
         $header = array($this->buildAuthorizationHeader($this->oauth), 'Expect:');
-        
-        $getfield = $this->getGetfield();
+
+        $getfield   = $this->getGetfield();
         $postfields = $this->getPostfields();
 
-        $options = array( 
-            CURLOPT_HTTPHEADER => $header,
-            CURLOPT_HEADER => false,
-            CURLOPT_URL => $this->url,
+        $options = array(
+            CURLOPT_HTTPHEADER     => $header,
+            CURLOPT_HEADER         => false,
+            CURLOPT_URL            => $this->url,
             CURLOPT_RETURNTRANSFER => true,
-            CURLOPT_TIMEOUT => 10,
+            CURLOPT_TIMEOUT        => 10,
         ) + $curlOptions;
 
-        if (!is_null($postfields))
-        {
+        if (!is_null($postfields)) {
             $options[CURLOPT_POSTFIELDS] = $postfields;
-        }
-        else
-        {
-            if ($getfield !== '')
-            {
+        } else {
+            if ($getfield !== '') {
                 $options[CURLOPT_URL] .= $getfield;
             }
         }
 
         $feed = curl_init();
+
         curl_setopt_array($feed, $options);
+
         $json = curl_exec($feed);
+
         curl_close($feed);
 
-        if ($return) { return $json; }
+        if ($return) {
+            return $json;
+        }
     }
-    
+
     /**
      * Private method to generate the base string used by cURL
-     * 
+     *
      * @param string $baseURI
      * @param string $method
-     * @param array $params
-     * 
+     * @param array  $params
+     *
      * @return string Built base string
      */
-    private function buildBaseString($baseURI, $method, $params) 
+    private function buildBaseString($baseURI, $method, $params)
     {
         $return = array();
+
         ksort($params);
-        
-        foreach($params as $key=>$value)
-        {
+
+        foreach ($params as $key => $value) {
             $return[] = "$key=" . $value;
         }
-        
-        return $method . "&" . rawurlencode($baseURI) . '&' . rawurlencode(implode('&', $return)); 
+
+        return $method . "&" . rawurlencode($baseURI) . '&' . rawurlencode(implode('&', $return));
     }
-    
+
     /**
      * Private method to generate authorization header used by cURL
-     * 
+     *
      * @param array $oauth Array of oauth data generated by buildOauth()
-     * 
+     *
      * @return string $return Header used by cURL for request
-     */    
-    private function buildAuthorizationHeader($oauth) 
+     */
+    private function buildAuthorizationHeader($oauth)
     {
         $return = 'Authorization: OAuth ';
         $values = array();
-        
-        foreach($oauth as $key => $value)
-        {
+
+        foreach ($oauth as $key => $value) {
             $values[] = "$key=\"" . rawurlencode($value) . "\"";
         }
-        
+
         $return .= implode(', ', $values);
+
         return $return;
     }
-
 }

--- a/TwitterAPIExchange.php
+++ b/TwitterAPIExchange.php
@@ -173,11 +173,13 @@ class TwitterAPIExchange
     /**
      * Perform the actual data retrieval from the API
      * 
-     * @param boolean $return If true, returns data.
+     * @param boolean $return      If true, returns data.
+     * @param array   $curlOptions Optional array of CURL Options
      * 
      * @return string json If $return param is true, returns json data.
+     * @throws Exception
      */
-    public function performRequest($return = true)
+    public function performRequest($return = true, $curlOptions = array())
     {
         if (!is_bool($return)) 
         { 
@@ -195,7 +197,7 @@ class TwitterAPIExchange
             CURLOPT_URL => $this->url,
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_TIMEOUT => 10,
-        );
+        ) + $curlOptions;
 
         if (!is_null($postfields))
         {


### PR DESCRIPTION
This pull request contains a very simple addition of allowing the use of additional curl options to be set for requests against the twitter api.

*Attention*: The pull request also contains Code-Style Improvements, therefore it looks far more than it is. The only code-change happening is within `performReqeust()` (new line 189 and 206).

### Why?

Environments are different all around the world and thus the need for specific curl options vary a lot. While the defaults provided are quite sane, they do not cover two of the most commonly known use-cases:

- `CURLOPT_SSL_VERIFYPEER`
- `CURLOPT_PROXY` as well as `CURLOPT_PROXYPORT`

As there is no way to set these options properly for the single request using the current class and extending the class is a bit annoying (hello privates), we need this way to set the options.

### How to use it?

The `Union`- operator of PHP merges 2 arrays based on their key. See http://php.net/manual/en/language.operators.array.php#86379

This allows us to set additional options in the likes of

```php
$curlOptions = array(
    CURLOPT_SSL_VERIFYPEER => false
);

if (!strstr($_SERVER['HTTP_HOST'], 'your-special-host-that-needs-a-proxy')) {
    $curlOptions[CURLOPT_PROXY]     = 'http://your.proxy:8080';
    $curlOptions[CURLOPT_PROXYPORT] = 8080;
}

$response = $twitter->setGetfield($getfield)
    ->buildOauth($url, $requestMethod)
    ->performRequest(true, $curlOptions);
```

### BC Breaks?

None. A sane default is provided and only has impact if the new - optional - parameter is actively used. 

No differences in any PHP Version. One failure on an older HHVM release which can likely be neglected. Whoever uses HHVM updates a lot... See http://3v4l.org/KZBD9
