### PR TITLE
Fix for failing POST methods

### DIFF
--- a/TwitterAPIExchange.php
+++ b/TwitterAPIExchange.php
@@ -159,6 +159,14 @@ class TwitterAPIExchange
             }
         }
         
+        $postfields = $this->getPostfields();
+
+        if (!is_null($postfields)) {
+            foreach ($postfields as $key => $value) {
+                $oauth[$key] = $value;
+            }
+        }
+
         $base_info = $this->buildBaseString($url, $requestMethod, $oauth);
         $composite_key = rawurlencode($consumer_secret) . '&' . rawurlencode($oauth_access_token_secret);
         $oauth_signature = base64_encode(hash_hmac('sha1', $base_info, $composite_key, true));

--- a/TwitterAPIExchange.php
+++ b/TwitterAPIExchange.php
@@ -199,7 +199,7 @@ class TwitterAPIExchange
 
         if (!is_null($postfields))
         {
-            $options[CURLOPT_POSTFIELDS] = $postfields;
+            $options[CURLOPT_POSTFIELDS] = http_build_query($postfields);
         }
         else
         {

--- a/TwitterAPIExchange.php
+++ b/TwitterAPIExchange.php
@@ -268,7 +268,10 @@ class TwitterAPIExchange
         
         foreach($oauth as $key => $value)
         {
-            $values[] = "$key=\"" . rawurlencode($value) . "\"";
+            if (in_array($key, array('oauth_consumer_key', 'oauth_nonce', 'oauth_signature',
+                'oauth_signature_method', 'oauth_timestamp', 'oauth_token', 'oauth_version'))) {
+                $values[] = "$key=\"" . rawurlencode($value) . "\"";
+            }
         }
         
         $return .= implode(', ', $values);

--- a/TwitterAPIExchange.php
+++ b/TwitterAPIExchange.php
@@ -21,6 +21,7 @@ class TwitterAPIExchange
     private $getfield;
     protected $oauth;
     public $url;
+    public $requestMethod;
 
     /**
      * Create the API access object. Requires an array of settings::
@@ -173,6 +174,7 @@ class TwitterAPIExchange
         $oauth['oauth_signature'] = $oauth_signature;
         
         $this->url = $url;
+        $this->requestMethod = $requestMethod;
         $this->oauth = $oauth;
         
         return $this;
@@ -192,6 +194,10 @@ class TwitterAPIExchange
             throw new Exception('performRequest parameter must be true or false'); 
         }
         
+        if (!isset($this->oauth['oauth_signature'])) {
+            $this->buildOauth($this->url, $this->requestMethod);
+        }
+
         $header = array($this->buildAuthorizationHeader($this->oauth), 'Expect:');
         
         $getfield = $this->getGetfield();

--- a/TwitterAPIExchange.php
+++ b/TwitterAPIExchange.php
@@ -73,6 +73,11 @@ class TwitterAPIExchange
         
         $this->postfields = $array;
         
+        // rebuild oAuth
+        if (isset($this->oauth['oauth_signature'])) {
+            $this->buildOauth($this->url, $this->requestMethod);
+        }
+
         return $this;
     }
     
@@ -194,10 +199,6 @@ class TwitterAPIExchange
             throw new Exception('performRequest parameter must be true or false'); 
         }
         
-        if (!isset($this->oauth['oauth_signature'])) {
-            $this->buildOauth($this->url, $this->requestMethod);
-        }
-
         $header = array($this->buildAuthorizationHeader($this->oauth), 'Expect:');
         
         $getfield = $this->getGetfield();

--- a/TwitterAPIExchange.php
+++ b/TwitterAPIExchange.php
@@ -248,7 +248,7 @@ class TwitterAPIExchange
         
         foreach($params as $key=>$value)
         {
-            $return[] = "$key=" . $value;
+            $return[] = rawurlencode($key) . '=' . rawurlencode($value);
         }
         
         return $method . "&" . rawurlencode($baseURI) . '&' . rawurlencode(implode('&', $return)); 


### PR DESCRIPTION
Previously, trying to add or remove a user from a list failed with an error

````
{"errors":[{"code":112,"message":"You must specify either a list ID or a slug and owner."}]}
````

This was despite passing both slug and owner as parameters to the `setPostFields` method.

After a lot of experimentation, it turns out that these endpoints required the data to be sent as `application/x-www-form-urlencoded` rather than `multipart/form-data` for the parameters to be recogised.

However, fixing this threw up another problem:  I was now receiving this error for both endpoints:

````
{"errors":[{"code":32,"message":"Could not authenticate you."}]}
````

It turns out that the POST parameters were not being correctly used to assemble the oAuth base string which is required for authenticated requests.

This pull request fixes both of these issues.

One thing to note, because of the change, you _must_ call `setPostFields` *before* the `buildOauth` method like this:

````
        $json = $twitter
                ->setPostfields( $postFields )
                ->buildOauth( $url, $requestMethod )
                ->performRequest();

````
