### PR TITLE
URL decode GET parameters before adding to oAuth - fixes #111

### DIFF
--- a/TwitterAPIExchange.php
+++ b/TwitterAPIExchange.php
@@ -139,7 +139,8 @@ class TwitterAPIExchange
         $getfields = preg_replace('/^\?/', '', explode('&', $string));
         $params = array();
 
-        foreach ($getfields as $field) {
+        foreach ($getfields as $field)
+        {
             list($key, $value) = explode('=', $field);
             $params[$key] = $value;
         }

--- a/TwitterAPIExchange.php
+++ b/TwitterAPIExchange.php
@@ -136,7 +136,15 @@ class TwitterAPIExchange
             throw new Exception('You can only choose get OR post fields.'); 
         }
         
-        $this->getfield = $string;
+        $getfields = preg_replace('/^\?/', '', explode('&', $string));
+        $params = array();
+
+        foreach ($getfields as $field) {
+            list($key, $value) = explode('=', $field);
+            $params[$key] = $value;
+        }
+
+        $this->getfield = '?' . http_build_query($params);
         
         return $this;
     }

--- a/TwitterAPIExchange.php
+++ b/TwitterAPIExchange.php
@@ -210,7 +210,7 @@ class TwitterAPIExchange
                 /** In case a null is passed through **/
                 if (isset($split[1]))
                 {
-                    $oauth[$split[0]] = $split[1];
+                    $oauth[$split[0]] = urldecode($split[1]);
                 }
             }
         }

--- a/TwitterAPIExchange.php
+++ b/TwitterAPIExchange.php
@@ -136,10 +136,6 @@ class TwitterAPIExchange
             throw new Exception('You can only choose get OR post fields.'); 
         }
         
-        $search = array('#', ',', '+', ':');
-        $replace = array('%23', '%2C', '%2B', '%3A');
-        $string = str_replace($search, $replace, $string);  
-        
         $this->getfield = $string;
         
         return $this;


### PR DESCRIPTION
GET parameters that have been URL encoded need to be decoded before adding to oAuth.

