### PR TITLE
homeTimeline test fix

### DIFF
--- a/test/TwitterAPIExchangeTest.php
+++ b/test/TwitterAPIExchangeTest.php
@@ -105,7 +105,7 @@ class TwitterAPIExchangeTest extends \PHPUnit_Framework_TestCase
     {
         $url    = 'https://api.twitter.com/1.1/statuses/home_timeline.json';
         $method = 'GET';
-        $params = '?user_id=3232926711';
+        $params = '?user_id=3232926711&max_id=595155660494471168';
 
         $data     = $this->exchange->request($url, $method, $params);
         $expected = "Test Tweet";


### PR DESCRIPTION
Test was picking up retweets instead of the correct tweet ID to check