### PR TITLE
Allow additional Curl options to be set

### DIFF
--- a/TwitterAPIExchange.php
+++ b/TwitterAPIExchange.php
@@ -247,12 +247,13 @@ class TwitterAPIExchange
      * Perform the actual data retrieval from the API
      * 
      * @param boolean $return If true, returns data. This is left in for backward compatibility reasons
+     * @param array $curlOptions Additional Curl options for this request
      *
      * @throws \Exception
      * 
      * @return string json If $return param is true, returns json data.
      */
-    public function performRequest($return = true)
+    public function performRequest($return = true, $curlOptions = array())
     {
         if (!is_bool($return))
         {
@@ -270,7 +271,7 @@ class TwitterAPIExchange
             CURLOPT_URL => $this->url,
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_TIMEOUT => 10,
-        );
+        ) + $curlOptions;
 
         if (!is_null($postfields))
         {
@@ -352,12 +353,13 @@ class TwitterAPIExchange
      * @param string $url
      * @param string $method
      * @param string $data
+     * @param array $curlOptions
      *
      * @throws \Exception
      *
      * @return string The json response from the server
      */
-    public function request($url, $method = 'get', $data = null)
+    public function request($url, $method = 'get', $data = null, $curlOptions = array())
     {
         if (strtolower($method) === 'get')
         {
@@ -368,6 +370,6 @@ class TwitterAPIExchange
             $this->setPostfields($data);
         }
 
-        return $this->buildOauth($url, $method)->performRequest();
+        return $this->buildOauth($url, $method)->performRequest(true, $curlOptions);
     }
 }

--- a/test/TwitterAPIExchangeTest.php
+++ b/test/TwitterAPIExchangeTest.php
@@ -271,4 +271,16 @@ class TwitterAPIExchangeTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNotCount(1, $data);
     }
+
+    public function testAdditionalCurlOptions()
+    {
+        $url    = 'https://api.twitter.com/1.1/search/tweets.json';
+        $method = 'GET';
+        $params = '?q=#twitter';
+
+        $data = $this->exchange->request($url, $method, $params, array(CURLOPT_ENCODING => ''));
+        $data = (array)@json_decode($data, true);
+
+        $this->assertNotCount(1, $data);
+    }
 }


### PR DESCRIPTION
This allows custom Curl options to be set (e.g. as referenced in https://github.com/J7mbo/twitter-api-php/issues/84 and https://github.com/J7mbo/twitter-api-php/pull/94)

I've added a new test to show that compressed responses are now supported.
