### PR TITLE
curl_options

### DIFF
--- a/TwitterAPIExchange.php
+++ b/TwitterAPIExchange.php
@@ -177,7 +177,7 @@ class TwitterAPIExchange
      * Build the Oauth object using params set in construct and additionals
      * passed to this method. For v1.1, see: https://dev.twitter.com/docs/api/1.1
      *
-     * @param string $url The API url to use. Example: https://api.twitter.com/1.1/search/tweets.json
+     * @param string $url           The API url to use. Example: https://api.twitter.com/1.1/search/tweets.json
      * @param string $requestMethod Either POST or GET
      *
      * @throws \Exception
@@ -246,13 +246,14 @@ class TwitterAPIExchange
     /**
      * Perform the actual data retrieval from the API
      * 
-     * @param boolean $return If true, returns data. This is left in for backward compatibility reasons
+     * @param boolean $return      If true, returns data. This is left in for backward compatibility reasons
+     * @param array   $curlOptions Additional Curl options for this request
      *
      * @throws \Exception
      * 
      * @return string json If $return param is true, returns json data.
      */
-    public function performRequest($return = true)
+    public function performRequest($return = true, $curlOptions = array())
     {
         if (!is_bool($return))
         {
@@ -270,7 +271,7 @@ class TwitterAPIExchange
             CURLOPT_URL => $this->url,
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_TIMEOUT => 10,
-        );
+        ) + $curlOptions;
 
         if (!is_null($postfields))
         {
@@ -352,12 +353,13 @@ class TwitterAPIExchange
      * @param string $url
      * @param string $method
      * @param string $data
+     * @param array  $curlOptions
      *
      * @throws \Exception
      *
      * @return string The json response from the server
      */
-    public function request($url, $method = 'get', $data = null)
+    public function request($url, $method = 'get', $data = null, $curlOptions = array())
     {
         if (strtolower($method) === 'get')
         {
@@ -368,6 +370,6 @@ class TwitterAPIExchange
             $this->setPostfields($data);
         }
 
-        return $this->buildOauth($url, $method)->performRequest();
+        return $this->buildOauth($url, $method)->performRequest(true, $curlOptions);
     }
 }

--- a/test/TwitterAPIExchangeTest.php
+++ b/test/TwitterAPIExchangeTest.php
@@ -271,4 +271,19 @@ class TwitterAPIExchangeTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNotCount(1, $data);
     }
+
+    /**
+     * Test to check that options passed to curl do not cause any issues
+     */
+    public function testAdditionalCurlOptions()
+    {
+        $url    = 'https://api.twitter.com/1.1/search/tweets.json';
+        $method = 'GET';
+        $params = '?q=#twitter';
+
+        $data = $this->exchange->request($url, $method, $params, array(CURLOPT_ENCODING => ''));
+        $data = (array)@json_decode($data, true);
+
+        $this->assertNotCount(1, $data);
+    }
 }


### PR DESCRIPTION
`performRequest()` now takes a second optional parameter `array $curlOptions` so people can add terrible choices to their cURL requests like setting peer verification to false!