### PR TITLE
Method for resetting fields implemented

### DIFF
--- a/TwitterAPIExchange.php
+++ b/TwitterAPIExchange.php
@@ -174,6 +174,16 @@ class TwitterAPIExchange
     }
     
     /**
+    * Resets the fields to allow a new query
+    * with different method
+    */
+    public function resetFields() {
+        $this->postfields = null;
+        $this->getfield = null;
+        return $this;
+    }
+    
+    /**
      * Build the Oauth object using params set in construct and additionals
      * passed to this method. For v1.1, see: https://dev.twitter.com/docs/api/1.1
      *


### PR DESCRIPTION
To allow reusing of the api-object we need the possibility to reset the post/get Field.
This code-change will help with that.
Example usage:
```php
$json = $this->api->resetFields()->setPostfields($params)
                        ->buildOauth($url, $method)
                        ->performRequest();
```