### PR TITLE
Added property HTTPStatusCode

### DIFF
--- a/TwitterAPIExchange.php
+++ b/TwitterAPIExchange.php
@@ -60,6 +60,12 @@ class TwitterAPIExchange
     public $requestMethod;
 
     /**
+     * the HTTP status code Twitter returns
+     * @var number
+     */
+    public $HTTPStatusCode;
+
+    /**
      * Create the API access object. Requires an array of settings::
      * oauth access token, oauth access token secret, consumer key, consumer secret
      * These are all available by creating your own application on dev.twitter.com
@@ -297,6 +303,8 @@ class TwitterAPIExchange
         $feed = curl_init();
         curl_setopt_array($feed, $options);
         $json = curl_exec($feed);
+        
+        $this->HTTPStatusCode = curl_getinfo($feed, CURLINFO_HTTP_CODE);
 
         if (($error = curl_error($feed)) !== '')
         {

--- a/TwitterAPIExchange.php
+++ b/TwitterAPIExchange.php
@@ -394,7 +394,7 @@ class TwitterAPIExchange
     /**
      * Get the HTTP status code for the previous request
      * 
-     * @return number The HTTP status code from the API server
+     * @return integer
      */
     public function getHttpStatusCode() 
     {

--- a/TwitterAPIExchange.php
+++ b/TwitterAPIExchange.php
@@ -60,10 +60,11 @@ class TwitterAPIExchange
     public $requestMethod;
 
     /**
-     * the HTTP status code Twitter returns
-     * @var number
+     * The HTTP status code from the previous request
+     * 
+     * @var int
      */
-    public $HTTPStatusCode;
+    protected $httpStatusCode;
 
     /**
      * Create the API access object. Requires an array of settings::
@@ -304,7 +305,7 @@ class TwitterAPIExchange
         curl_setopt_array($feed, $options);
         $json = curl_exec($feed);
         
-        $this->HTTPStatusCode = curl_getinfo($feed, CURLINFO_HTTP_CODE);
+        $this->httpStatusCode = curl_getinfo($feed, CURLINFO_HTTP_CODE);
 
         if (($error = curl_error($feed)) !== '')
         {
@@ -388,5 +389,15 @@ class TwitterAPIExchange
         }
 
         return $this->buildOauth($url, $method)->performRequest(true, $curlOptions);
+    }
+    
+    /**
+     * Get the HTTP status code for the previous request
+     * 
+     * @return number The HTTP status code from the API server
+     */
+    public function getHttpStatusCode() 
+    {
+        return $this->httpStatusCode;
     }
 }


### PR DESCRIPTION
Change-Id: If7774830ebe204b90400f14d4743c051d15f2955

The HTTP status code that Twitter returns after each request may contain relevant information for debugging and API error handling. Full list here: https://dev.twitter.com/overview/api/response-codes

Usage example:
```php
$oApi = new TwitterAPIExchange(...);
$response = $oApi->buildOauth(...)->setPostfields(...)->performRequest();
if ($oApi->HTTPStatusCode != 200) {
   // error handling here
} else {
   // parse $response
}
```