### PR TITLE
made readme more clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ require_once('TwitterAPIExchange.php');
 ```php
 $settings = array(
     'consumer_key' => "YOUR_CONSUMER_KEY",
-    'consumer_secret' => "YOUR_CONSUMER_SECRET"
+    'consumer_secret' => "YOUR_CONSUMER_SECRET",
     'oauth_access_token' => "YOUR_OAUTH_ACCESS_TOKEN",
-    'oauth_access_token_secret' => "YOUR_OAUTH_ACCESS_TOKEN_SECRET",
+    'oauth_access_token_secret' => "YOUR_OAUTH_ACCESS_TOKEN_SECRET"
 );
 ```
 

--- a/README.md
+++ b/README.md
@@ -54,10 +54,10 @@ require_once('TwitterAPIExchange.php');
 
 ```php
 $settings = array(
-    'oauth_access_token' => "YOUR_OAUTH_ACCESS_TOKEN",
-    'oauth_access_token_secret' => "YOUR_OAUTH_ACCESS_TOKEN_SECRET",
     'consumer_key' => "YOUR_CONSUMER_KEY",
     'consumer_secret' => "YOUR_CONSUMER_SECRET"
+    'oauth_access_token' => "YOUR_OAUTH_ACCESS_TOKEN",
+    'oauth_access_token_secret' => "YOUR_OAUTH_ACCESS_TOKEN_SECRET",
 );
 ```
 


### PR DESCRIPTION
Put the keys in the same order as the twitter keys page to avoid PEBKAC errors.