### PR TITLE
Clear the current get and post fields after a request has been processed - This saves having to reinstatement TwitterAPIExchange for every API call.

### DIFF
--- a/TwitterAPIExchange.php
+++ b/TwitterAPIExchange.php
@@ -306,6 +306,9 @@ class TwitterAPIExchange
         }
 
         curl_close($feed);
+        
+        $this->getfield = null;
+        $this->postfield = null;
 
         return $json;
     }


### PR DESCRIPTION
Clear the current get and post fields after a request has been processed - This saves having to reinstatement TwitterAPIExchange for every API call.

Previously if you were performing a GET call and then a POST call an exception would be thrown because you can't have both get and set fields present. This resolves this bug.