### PR TITLE
Clear request fields after each request

### DIFF
--- a/TwitterAPIExchange.php
+++ b/TwitterAPIExchange.php
@@ -14,6 +14,12 @@
  */
 class TwitterAPIExchange
 {
+    
+    /**
+     * @var bool
+     */
+    const CLEAR_REQUEST_FIELDS_AFTER_EACH_REQUEST = false;
+    
     /**
      * @var string
      */
@@ -316,8 +322,21 @@ class TwitterAPIExchange
         }
 
         curl_close($feed);
+        
+        // Clear the current GET/POST fields in preperation for future requests
+        $this->clearRequestFields();
 
         return $json;
+    }
+    
+    /**
+     * Clears the current GET/POST fields in preperation for future requests
+     */
+    public function clearRequestFields() {
+        if (self::CLEAR_REQUEST_FIELDS_AFTER_EACH_REQUEST) {
+            $this->getfield = null;
+            $this->postfields = null;
+        }
     }
 
     /**


### PR DESCRIPTION
Following on from my previous pull request submitted into the Master branch:

Introduced a new public method (clearRequestFields) for clearing the request fields after each API request.

Due to BC concerns, this no longer clears the fields by default. A new constant (CLEAR_REQUEST_FIELDS_AFTER_EACH_REQUEST) has been introduced to control if the logic should change from it's existing behaviour.

By default, these changes don't affect any of the existing behaviour.