### PR TITLE
Explicitly use '&' in http_build_query()

### DIFF
--- a/TwitterAPIExchange.php
+++ b/TwitterAPIExchange.php
@@ -166,7 +166,7 @@ class TwitterAPIExchange
             }
         }
 
-        $this->getfield = '?' . http_build_query($params);
+        $this->getfield = '?' . http_build_query($params, '', '&');
 
         return $this;
     }
@@ -298,7 +298,7 @@ class TwitterAPIExchange
 
         if (!is_null($postfields))
         {
-            $options[CURLOPT_POSTFIELDS] = http_build_query($postfields);
+            $options[CURLOPT_POSTFIELDS] = http_build_query($postfields, '', '&');
         }
         else
         {


### PR DESCRIPTION
Same as PR https://github.com/J7mbo/twitter-api-php/pull/172 but to develop branch.

---

Some hosting environments are configured to use `&amp;` rather than `&`. Calling the twitter api end up with error #32 / `Could not authenticate you`