### PR TITLE
Allow overriding of curl options

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ $url = 'https://api.twitter.com/1.1/blocks/create.json';
 $requestMethod = 'POST';
 ```
 
-#### Choose POST fields ####
+#### Choose POST fields (or PUT fields if you're using PUT) ####
 
 ```php
 $postfields = array(

--- a/TwitterAPIExchange.php
+++ b/TwitterAPIExchange.php
@@ -166,7 +166,7 @@ class TwitterAPIExchange
             }
         }
 
-        $this->getfield = '?' . http_build_query($params);
+        $this->getfield = '?' . http_build_query($params, '', '&');
 
         return $this;
     }
@@ -298,7 +298,7 @@ class TwitterAPIExchange
 
         if (!is_null($postfields))
         {
-            $options[CURLOPT_POSTFIELDS] = http_build_query($postfields);
+            $options[CURLOPT_POSTFIELDS] = http_build_query($postfields, '', '&');
         }
         else
         {

--- a/TwitterAPIExchange.php
+++ b/TwitterAPIExchange.php
@@ -288,13 +288,13 @@ class TwitterAPIExchange
             $curlOptions[CURLOPT_CUSTOMREQUEST] = $this->requestMethod;
         }
 
-        $options = array(
+        $options = $curlOptions + array(
             CURLOPT_HTTPHEADER => $header,
             CURLOPT_HEADER => false,
             CURLOPT_URL => $this->url,
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_TIMEOUT => 10,
-        ) + $curlOptions;
+        );
 
         if (!is_null($postfields))
         {

--- a/TwitterAPIExchange.php
+++ b/TwitterAPIExchange.php
@@ -111,7 +111,7 @@ class TwitterAPIExchange
     {
         if (!is_null($this->getGetfield()))
         {
-            throw new Exception('You can only choose get OR post fields.');
+            throw new Exception('You can only choose get OR post fields (post fields include put).');
         }
 
         if (isset($array['status']) && substr($array['status'], 0, 1) === '@')
@@ -130,7 +130,8 @@ class TwitterAPIExchange
         $this->postfields = $array;
 
         // rebuild oAuth
-        if (isset($this->oauth['oauth_signature'])) {
+        if (isset($this->oauth['oauth_signature']))
+        {
             $this->buildOauth($this->url, $this->requestMethod);
         }
 
@@ -150,7 +151,7 @@ class TwitterAPIExchange
     {
         if (!is_null($this->getPostfields()))
         {
-            throw new Exception('You can only choose get OR post fields.');
+            throw new Exception('You can only choose get OR post / post fields.');
         }
 
         $getfields = preg_replace('/^\?/', '', explode('&', $string));
@@ -203,9 +204,9 @@ class TwitterAPIExchange
      */
     public function buildOauth($url, $requestMethod)
     {
-        if (!in_array(strtolower($requestMethod), array('post', 'get')))
+        if (!in_array(strtolower($requestMethod), array('post', 'get', 'put')))
         {
-            throw new Exception('Request method must be either POST or GET');
+            throw new Exception('Request method must be either POST, GET or PUT');
         }
 
         $consumer_key              = $this->consumer_key;
@@ -253,9 +254,9 @@ class TwitterAPIExchange
         $oauth_signature = base64_encode(hash_hmac('sha1', $base_info, $composite_key, true));
         $oauth['oauth_signature'] = $oauth_signature;
 
-        $this->url = $url;
+        $this->url           = $url;
         $this->requestMethod = $requestMethod;
-        $this->oauth = $oauth;
+        $this->oauth         = $oauth;
 
         return $this;
     }
@@ -281,6 +282,11 @@ class TwitterAPIExchange
 
         $getfield = $this->getGetfield();
         $postfields = $this->getPostfields();
+
+        if (strtolower($this->requestMethod) === 'put')
+        {
+            $curlOptions[CURLOPT_CUSTOMREQUEST] = $this->requestMethod;
+        }
 
         $options = array(
             CURLOPT_HTTPHEADER => $header,

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     ],
     "autoload": {
-        "files": ["TwitterAPIExchange.php"]
+        "classmap": ["TwitterAPIExchange.php"]
     },
     "extra": {
         "branch-alias": {

--- a/test/TwitterAPIExchangeTest.php
+++ b/test/TwitterAPIExchangeTest.php
@@ -105,7 +105,7 @@ class TwitterAPIExchangeTest extends \PHPUnit_Framework_TestCase
     {
         $url    = 'https://api.twitter.com/1.1/statuses/home_timeline.json';
         $method = 'GET';
-        $params = '?user_id=3232926711&max_id=595155660494471168';
+        $params = '?user_id=3232926711&max_id=756123701888839681';
 
         $data     = $this->exchange->request($url, $method, $params);
         $expected = "Test Tweet";
@@ -303,5 +303,23 @@ class TwitterAPIExchangeTest extends \PHPUnit_Framework_TestCase
 
         $data = $this->exchange->request($url, $method, $params);
         $this->assertContains('created_at', $data);
+    }
+
+    /**
+     * Thanks to Sharath at eywamedia for bringint this to my attention
+     */
+    public function testPut()
+    {
+        $url    = 'https://ads-api.twitter.com/0/accounts/hkk5/campaigns/8zwv';
+        $method = 'PUT';
+        $params = array (
+            'name'   => 'Important',
+            'paused' => true
+        );
+
+        $data = $this->exchange->request($url, $method, $params);
+
+        /** If we get this back, then it looks like we can support PUT! :-) **/
+        $this->assertContains('UNAUTHORIZED_CLIENT_APPLICATION', $data);
     }
 }


### PR DESCRIPTION
This was causing a problem because even if the user specified a curl option it was ignored because the value in the "defaults array" overrode it.

> If you want to append array elements from the second array to the first array while not overwriting the elements from the first array and not re-indexing, use the + array union operator. The keys from the first array will be preserved. If an array key exists in both arrays, then the element from the first array will be used and the matching key's element from the second array will be ignored.
http://php.net/manual/en/function.array-merge.php