### PR TITLE
Allow overriding of curl options

### DIFF
--- a/TwitterAPIExchange.php
+++ b/TwitterAPIExchange.php
@@ -288,13 +288,13 @@ class TwitterAPIExchange
             $curlOptions[CURLOPT_CUSTOMREQUEST] = $this->requestMethod;
         }
 
-        $options = array(
+        $options = $curlOptions + array(
             CURLOPT_HTTPHEADER => $header,
             CURLOPT_HEADER => false,
             CURLOPT_URL => $this->url,
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_TIMEOUT => 10,
-        ) + $curlOptions;
+        );
 
         if (!is_null($postfields))
         {


### PR DESCRIPTION
This was causing a problem because even if the user specified a curl option it was ignored because the value in the "defaults array" overrode it.

> If you want to append array elements from the second array to the first array while not overwriting the elements from the first array and not re-indexing, use the + array union operator. The keys from the first array will be preserved. If an array key exists in both arrays, then the element from the first array will be used and the matching key's element from the second array will be ignored.
http://php.net/manual/en/function.array-merge.php