### PR TITLE
Get response headers from request

### DIFF
--- a/test/TwitterAPIExchangeTest.php
+++ b/test/TwitterAPIExchangeTest.php
@@ -105,10 +105,10 @@ class TwitterAPIExchangeTest extends \PHPUnit_Framework_TestCase
     {
         $url    = 'https://api.twitter.com/1.1/statuses/home_timeline.json';
         $method = 'GET';
-        $params = '?user_id=3232926711&max_id=756123701888839681';
+        $params = '?user_id=3232926711&max_id=943202220002234369';
 
         $data     = $this->exchange->request($url, $method, $params);
-        $expected = "Test Tweet";
+        $expected = "Pull up!";
 
         $this->assertContains($expected, $data);
     }

--- a/test/TwitterAPIExchangeTest.php
+++ b/test/TwitterAPIExchangeTest.php
@@ -335,4 +335,16 @@ class TwitterAPIExchangeTest extends \PHPUnit_Framework_TestCase
 
         $this->assertContains('UNAUTHORIZED_CLIENT_APPLICATION', $data);
     }
+
+    public function testResponseHeaders()
+    {
+        $url    = 'https://api.twitter.com/1.1/users/lookup.json';
+        $method = 'GET';
+        $params = '?screen_name=J7mbo';
+
+        $this->exchange->includeResponseHeaders()->request($url, $method, $params);
+        $headers = $this->exchange->getResponseHeaders();
+
+        $this->assertArrayHasKey('http_code', $headers);
+    }
 }


### PR DESCRIPTION
I wanted to be able to get the response headers from a request to handle the x-rate-limit-remaining in our app.

I've made it an optional setting before the request and added the ability to retrieve them after the request via a private property.

Added a phpunit test for this going forwards too.