### PR TITLE
Update error handling to work on Google AppEngine

### DIFF
--- a/TwitterAPIExchange.php
+++ b/TwitterAPIExchange.php
@@ -314,14 +314,16 @@ class TwitterAPIExchange
 
         $this->httpStatusCode = curl_getinfo($feed, CURLINFO_HTTP_CODE);
 
-        if (($error = curl_error($feed)) !== '')
-        {
-            curl_close($feed);
-
-            throw new \Exception($error);
+        $error = false;
+        if ($json === false) {
+          $error = curl_error($feed);
         }
 
         curl_close($feed);
+
+        if ($error !== false) {
+          throw new \Exception($error);
+        }
 
         return $json;
     }


### PR DESCRIPTION
When using cURL Lite on AppEngine this library always fails due to a bug in cURL Lite. With a few modifications it's possible to make it all work. Please see my changes to the error handling logic in performRequest().