### PR TITLE
Fix additionnal CURLOPT_HTTPHEADER bug

### DIFF
--- a/TwitterAPIExchange.php
+++ b/TwitterAPIExchange.php
@@ -287,6 +287,13 @@ class TwitterAPIExchange
         {
             $curlOptions[CURLOPT_CUSTOMREQUEST] = $this->requestMethod;
         }
+        
+        if (isset($curlOptions[CURLOPT_HTTPHEADER])) {
+            foreach ($curlOptions[CURLOPT_HTTPHEADER] as $additionnalHeader) {
+                $header[] = $additionnalHeader;
+            }
+            unset($curlOptions[CURLOPT_HTTPHEADER]);
+        }
 
         $options = $curlOptions + array(
             CURLOPT_HTTPHEADER => $header,


### PR DESCRIPTION
When we add additionnal header in the call to the performRequest method like this : 
$return_api = $this->twitter->buildOauth($url, $requestMethod)->performRequest(true, [
                CURLOPT_HTTPHEADER => array('Content-Type:application/json'),
                CURLOPT_POSTFIELDS => json_encode($postfields)
            ]);
Authentication data is not sent in the request, So we have this type of return : 

{"errors":[{"code":215,"message":"Bad Authentication data."}]}